### PR TITLE
Batch append page children to avoid exceeding notion limit

### DIFF
--- a/gkeep2notion.py
+++ b/gkeep2notion.py
@@ -187,8 +187,11 @@ def create_page(notion: Client, page: Page) -> Page:
     """Creates a page in Notion and saves page.id"""
     throttle.wait()
     notion_page = notion.pages.create(parent=page.parent,
-                                      properties=page.properties,
-                                      children=page.children)
+                                      properties=page.properties)
+    for i in range(0, len(page.children), 100):
+        notion.blocks.children.append(
+            notion_page["id"], children=page.children[i : i + 100]
+        )
     page.id = notion_page['id']
     return page
 


### PR DESCRIPTION
> There is a limit of 100 block children that can be appended by a single API request. Arrays of block children longer than 100 will result in an error.
https://developers.notion.com/reference/patch-block-children